### PR TITLE
travis-ci: updates for flux-core-v0.11 stable repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,9 @@ before_install:
   fi
 
 script:
+ # Unshallow repository so git describe works.
+ # (The one inside docker-run-checks may fail if git version is too old)
+ - git fetch --unshallow --tags
  - |
   src/test/docker/docker-run-checks.sh -j2 \
     --image=${IMG} \

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       name: 'python lint'
       language: 'python'
       python: '3.6'
-      install: pip install --upgrade pylint
+      install: pip install 'pylint==2.2.2' --force-reinstall
       script: pylint --rcfile=src/bindings/python/.pylintrc src/bindings/python/flux
       before_deploy: skip
       deploy: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,9 @@ env:
    - TAP_DRIVER_QUIET=1
    - DOCKERREPO=fluxrm/flux-core
    - DOCKER_USERNAME=travisflux
-   - secure: "Uga2i1Yu0PvWMFzOYvM9yxnAMDTgY17ZqeFlIN8MV3uoTCy6y61GULrMkKuhuI1sUfyugpFWVKIJo5jwTpsfG84f3o9lUTRgLPpTA2Xls8A/rmurF/QacVv6hZ2Zs2LQVlrM8BkT36TpT2NfWW2D2238kovqz3l5gIZKMClMvyk="
+   # travis encrypt -r flux-framework/flux-core-v0.11
+   # DOCKER_PASSWORD=xxxx
+   - secure: "VzOP9JcziZ8qelU9PE7NJaSbZLoaQ0Ybu/DzqLVN0qfGer+u0R4RlTJvXROcGUQI2tnVWxlGwRqQOLuVNnHTBJGJIR5ZZQColKEsv+JguBjZV/E7o54SbkySptns7YJqf2c7S1//uPx2Vr8XZIlkaYL9Qk9MFfzcWVlszCfcq2zFt6PTwct0QvtuBAy1KwUSP9EygtIGvn5R1FWW/MbW7xn8P613XZ9M87zxJOgXbwhfcsC/VThbBcBx3BUCp5F+1BsQJQIVihQh87/s1EuoPo275g+kEh6S0DWyhWS3lyZ7DeuaYmymH7YTEk9HyC4Hd/0eBoMH/+MYOm+Zls2NLkpzuDz5DZWnsdyZzjOuU6W5h12luxRJMxkuTGNBTcKoj00DB2Z9trOX9n5QdwYp2HK1la21phJ0OmnRg402htSQdH5CHOBfv65O+i5zDyTd8oO2NQUwsatnhF4bK5nrP+MrqPbq9uhHw2siXazCnDTgadOVV3fE5a1uEZ2X7l3HVt6RngHX16/wlyrGCExHS7l2lCncUhBuCg2VMRIXwXrHx3K47GcJFu7TJoFyokg/KTEb0cuLqo4QKbF5P5XmfAAzoh7G1BW/9y50lKEEcJjQC26DKppTfHYz5eAp3+tXFNimB13eJJH5sqADQvuFrZbRo24fB3RSf77u3TSeQWU="
 
 cache:
   directories:
@@ -175,9 +177,11 @@ deploy:
   prerelease: true
   body: "View [Release Notes](${TAG_URI}/NEWS.md#${ANCHOR}) for flux-core ${TRAVIS_TAG}"
   api_key:
-    secure: I7ckZ7Ei9oLIe8WZ8OH3EgZz81IFCIekx+v/+g3sJa6q15URlfZhVVFtiUpsJRktHcb39AflWZiEIX+HdUZyXtuTt9IES1XBIKH7x/zUL0x6f1DZKAhBx9ktYzdO/M+SpmDUg6RYxcdjVmSHZ9u935TDo104U+dY0990ZSFrpco=
+    # Generate on github.com/settings/token personal access token and encrypt with
+    # travis encrypt -r flux-framework/repo_slug
+    secure: "dSZYBOVcI42xqVcjNTIymIpgbyuMquRxMcWDMplCxd6RzFLzwMkch+zJHDA4NvBma6tuemwnweGfsehRjjNu9Y3gyok6Tejwl8aURwt7i5u6baibmFXZNr33j4qS3GgEmygdFALyjj6fIvdbGD+jQxVNLbYkPgvbpekJwxw66gszKU3lujmcRQK3x0gHe65WqdLq6q0BcL2fttXIL3BleS1ac/cEya1IHfKMBw4Lnq3qrzh4vcB3FwdBJnw4D8JKFof/WpJYInDOtlufBxk0jagNyd/egK68O0aYnV1PNh3+goRIuGPTtEbRb8cjuNZ5ChR9Qed2z08es2ss96Q2ATnQfCbUxqzyYTiPqPlmrPHDRlFBjCHA3GtnKQzWHnOR5i6WWff4O4JHe4pg2AwSEkGQ/8sy81+r5LibLcbNK+NGQzBxxNnHTDx5bHPyN+Z2q6tLgNkD+5Tlfutjc1mk4np7kdiicFLIcVMWNMDm4YyMI6Y2OwQlMjkVRi1Z9RwUvAyp1ltw6FLQoLdMOfmnhrj65QLUoUuor7JIRPK4B5TYUjpSWnKd37MG5tkzrClmZ4iFIEB8/MY50Qy4Y7G1siuijgQoIOT1Z+8VUYL3snxDY6M1wl2KGpb3cU5Z/HP3AvX5jxLzqI+KQgttB0KLcHvA2Q/mth3rJPQ4CQY3+bM="
   on:
     # Only deploy from travis builder with GITHUB_RELEASES_DEPLOY set
     condition: $GITHUB_RELEASES_DEPLOY = "t"
     tags: true
-    repo: flux-framework/flux-core
+    repo: flux-framework/flux-core-v0.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,7 @@ env:
   global:
    - TAP_DRIVER_QUIET=1
    - DOCKERREPO=fluxrm/flux-core
+   - DOCKER_STABLE_PREFIX=-v0.11
    - DOCKER_USERNAME=travisflux
    # travis encrypt -r flux-framework/flux-core-v0.11
    # DOCKER_PASSWORD=xxxx
@@ -149,7 +150,7 @@ after_success:
      docker push ${TAGNAME}
      # If this is the bionic-base build, then also tag without image name:
      if echo "$TAGNAME" | grep -q "bionic-base"; then
-       t="${DOCKERREPO}:${TRAVIS_TAG:-latest}"
+       t="${DOCKERREPO}:${TRAVIS_TAG:${DOCKER_STABLE_PREFIX}-latest}"
        docker tag "$TAGNAME" ${t} && \
        docker push ${t}
      fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/flux-framework/flux-core.svg?branch=master)](https://travis-ci.org/flux-framework/flux-core)
-[![Coverage Status](https://coveralls.io/repos/flux-framework/flux-core/badge.svg?branch=master&service=github)](https://coveralls.io/github/flux-framework/flux-core?branch=master)
+[![Build Status](https://travis-ci.org/flux-framework/flux-core-v0.11.svg?branch=master)](https://travis-ci.org/flux-framework/flux-core)
+[![Coverage Status](https://coveralls.io/repos/flux-framework/flux-core-v0.11/badge.svg?branch=master&service=github)](https://coveralls.io/github/flux-framework/flux-core?branch=master)
 
 _NOTE: The interfaces of flux-core are being actively developed
 and are not yet stable._ The github issue tracker is the primary


### PR DESCRIPTION
This PR prepares the flux-core-v0.11 stable repo for travis-ci by backporting a couple of upstream travis-ci fixes (pylint and unshallow git repo), and updating links to badges in `README.md` to point to the correct repo.

The pylint fix is required to get past the style checks in travis-ci -- after that we'll see what else breaks and backport/add fixes as necessary on this PR branch.