### PR TITLE
broker: add global rundir from which broker.rundir is derived

### DIFF
--- a/doc/man1/flux-start.adoc
+++ b/doc/man1/flux-start.adoc
@@ -59,11 +59,12 @@ built with --enable-caliper. Unless CALI_LOG_VERBOSITY is already
 set in the environment, it will default to 0 for all brokers.
 
 *--scratchdir*='DIR'::
-For selfpmi bootstrap mode, set a pre-existing directory that will
-contain the generated broker.rundir directories for the instance.
-If a DIR is not set with this option, a unique temporary directory will
-be created for the lifetime of the instance and removed when the
-instance is destroyed.
+For selfpmi bootstrap mode, set the directory that will be
+used as the rundir directory for the instance. If the directory
+does not exist then it will be created during instance startup.
+If a DIR is not set with this option, a unique temporary directory
+will be created. Unless DIR was pre-existing, it will be removed
+when the instance is destroyed.
 
 *--wrap*='ARGS,...'::
 Wrap broker execution in a comma-separated list of arguments. This is

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -29,11 +29,19 @@ The number of ranks in the comms session.
 session-id::
 The identity of the comms session.
 
+rundir::
+A global, shared temporary directory available for scratch storage
+within the session. By default, a temporary directory is created
+for each broker rank, but if rundir is set on the command line, this
+directory may be shared by all broker ranks (typically only within
+a node).  If rundir does not exist, it is created and subsequently
+removed during session exit. An existing rundir is not removed at exit.
+
 broker.rundir::
-A temporary directory available for scratch storage within
-the session.  This directory is unique to the local rank.
-Cleanup of directory contents is the responsibility of
-the creator.
+A temporary directory available for per-rank scratch storage within
+the session. By default broker.rundir is set to "${rundir}/${rank}",
+which guarantees a unique directory per rank.  It is not advisable
+to override this attribute on the command line. Use rundir instead.
 
 persist-directory::
 A persistent directory available for storage on rank 0 only.
@@ -80,7 +88,8 @@ based overlay network.  This attribute will not be set on rank zero.
 
 local-uri::
 The Flux URI that should be passed to flux_open(1) to establish
-a connection to the local broker rank.
+a connection to the local broker rank. By default, local-uri is
+created as "local://<broker.rank>/local".
 
 parent-uri::
 The Flux URI that should be passed to flux_open(1) to establish

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -456,3 +456,4 @@ JOBNAME
 nokz
 LGPL
 SPDX
+startup

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -3,7 +3,7 @@ Description=Flux message broker
 
 [Service]
 Environment=FLUX_USERDB_OPTIONS=--default-rolemask=user
-ExecStart=@X_BINDIR@/flux broker -Sbroker.rundir=@X_RUNSTATEDIR@/flux -Sboot.method=config -Sboot.config_file=@X_SYSCONFDIR@/flux/conf.d/boot.conf sleep inf
+ExecStart=@X_BINDIR@/flux broker -Srundir=@X_RUNSTATEDIR@/flux -Sboot.method=config -Sboot.config_file=@X_SYSCONFDIR@/flux/conf.d/boot.conf sleep inf
 User=flux
 Group=flux
 RuntimeDirectory=flux

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -841,42 +841,63 @@ static int create_dummyattrs (flux_t *h, uint32_t rank, uint32_t size)
     return 0;
 }
 
-/* If user set the 'broker.rundir' attribute on the command line,
- * validate the directory and its permissions, and set the immutable flag
- * on the attribute.  If unset, create a unique directory and arrange to remove
- * it on exit.
+/*  Handle broker.rundir attribute.
+ *  If not set, create a temporary directory and use it as the rundir.
+ *  If set, attempt to create it if it doesn't exist. In either case,
+ *  validate directory persmissions and set the broker.rundir attribute
+ *  immutable. If the rundir is created by this function it will be
+ *  scheduled for later cleanup at broker exit. Pre-existing directories
+ *  are left intact.
  */
 static int create_rundir (attr_t *attrs)
 {
     const char *run_dir, *local_uri;
     char *dir = NULL;
     char *uri = NULL;
+    bool do_cleanup = true;
+    struct stat sb;
     int rc = -1;
 
-    if (attr_get (attrs, "broker.rundir", &run_dir, NULL) == 0) {
-        struct stat sb;
-        if (stat (run_dir, &sb) < 0)
-            goto done;
-        if (!S_ISDIR (sb.st_mode)) {
-            errno = ENOTDIR;
-            goto done;
-        }
-        if ((sb.st_mode & S_IRWXU) != S_IRWXU) {
-            errno = EPERM;
-            goto done;
-        }
-        if (attr_set_flags (attrs, "broker.rundir", FLUX_ATTRFLAG_IMMUTABLE) < 0)
-            goto done;
-    } else {
+    /*  If broker.rundir attribute isn't set, then create a temp directory
+     *   and use that as rundir. If directory was set, try to create it if
+     *   it doesn't exist. If directory was pre-existing, do not schedule
+     *   the dir for auto-cleanup at broker exit.
+     */
+    if (attr_get (attrs, "broker.rundir", &run_dir, NULL) < 0) {
         const char *tmpdir = getenv ("TMPDIR");
-        dir = xasprintf ("%s/flux-XXXXXX", tmpdir ? tmpdir : "/tmp");
-        if (!mkdtemp (dir))
+        if (asprintf (&dir, "%s/flux-XXXXXX", tmpdir ? tmpdir : "/tmp") < 0)
             goto done;
-        cleanup_push_string (cleanup_directory, dir);
-        if (attr_add (attrs, "broker.rundir", dir, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        if (!(run_dir = mkdtemp (dir)))
             goto done;
-        run_dir = dir;
+        if (attr_add (attrs, "broker.rundir", run_dir, 0) < 0)
+            goto done;
     }
+    else if (mkdir (run_dir, 0700) < 0) {
+        if (errno != EEXIST)
+            goto done;
+        /* Do not cleanup directory if we did not create it here
+         */
+        do_cleanup = false;
+    }
+
+    /*  Ensure created or existing directory is writeable:
+     */
+    if (stat (run_dir, &sb) < 0)
+        goto done;
+    if (!S_ISDIR (sb.st_mode)) {
+        errno = ENOTDIR;
+        goto done;
+    }
+    if ((sb.st_mode & S_IRWXU) != S_IRWXU) {
+        errno = EPERM;
+        goto done;
+    }
+
+    if (attr_set_flags (attrs, "broker.rundir", FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        goto done;
+    if (do_cleanup)
+        cleanup_push_string (cleanup_directory, run_dir);
+
     if (attr_get (attrs, "local-uri", &local_uri, NULL) < 0) {
         uri = xasprintf ("local://%s", run_dir);
         if (attr_add (attrs, "local-uri", uri,

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -159,6 +159,7 @@ static void runlevel_io_cb (runlevel_t *r, const char *name,
 
 static int create_persistdir (attr_t *attrs, uint32_t rank);
 static int create_rundir (attr_t *attrs);
+static void create_broker_rundir (overlay_t *ov, void *arg);
 static int create_dummyattrs (flux_t *h, uint32_t rank, uint32_t size);
 
 static int handle_event (broker_ctx_t *ctx, const flux_msg_t *msg);
@@ -400,6 +401,11 @@ int main (int argc, char *argv[])
 
     if (create_rundir (ctx.attrs) < 0)
         log_err_exit ("create_rundir");
+
+    /* Set & create broker.rundir *after* overlay initialization,
+     * when broker rank is determined.
+     */
+    overlay_set_init_callback (ctx.overlay, create_broker_rundir, ctx.attrs);
 
     /* Execute boot method selected by 'boot.method' attr.
      * Default is pmi.
@@ -841,35 +847,36 @@ static int create_dummyattrs (flux_t *h, uint32_t rank, uint32_t size)
     return 0;
 }
 
-/*  Handle broker.rundir attribute.
+/*  Handle global rundir attribute.
+ *
  *  If not set, create a temporary directory and use it as the rundir.
  *  If set, attempt to create it if it doesn't exist. In either case,
- *  validate directory persmissions and set the broker.rundir attribute
+ *  validate directory persmissions and set the rundir attribute
  *  immutable. If the rundir is created by this function it will be
  *  scheduled for later cleanup at broker exit. Pre-existing directories
  *  are left intact.
  */
 static int create_rundir (attr_t *attrs)
 {
-    const char *run_dir, *local_uri;
+    const char *run_dir;
     char *dir = NULL;
     char *uri = NULL;
     bool do_cleanup = true;
     struct stat sb;
     int rc = -1;
 
-    /*  If broker.rundir attribute isn't set, then create a temp directory
+    /*  If rundir attribute isn't set, then create a temp directory
      *   and use that as rundir. If directory was set, try to create it if
      *   it doesn't exist. If directory was pre-existing, do not schedule
      *   the dir for auto-cleanup at broker exit.
      */
-    if (attr_get (attrs, "broker.rundir", &run_dir, NULL) < 0) {
+    if (attr_get (attrs, "rundir", &run_dir, NULL) < 0) {
         const char *tmpdir = getenv ("TMPDIR");
         if (asprintf (&dir, "%s/flux-XXXXXX", tmpdir ? tmpdir : "/tmp") < 0)
             goto done;
         if (!(run_dir = mkdtemp (dir)))
             goto done;
-        if (attr_add (attrs, "broker.rundir", run_dir, 0) < 0)
+        if (attr_add (attrs, "rundir", run_dir, 0) < 0)
             goto done;
     }
     else if (mkdir (run_dir, 0700) < 0) {
@@ -893,22 +900,49 @@ static int create_rundir (attr_t *attrs)
         goto done;
     }
 
-    if (attr_set_flags (attrs, "broker.rundir", FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    /*  rundir is now fixed, so make the attribute immutable, and
+     *   schedule the dir for cleanup at exit if we created it here.
+     */
+    if (attr_set_flags (attrs, "rundir", FLUX_ATTRFLAG_IMMUTABLE) < 0)
         goto done;
     if (do_cleanup)
-        cleanup_push_string (cleanup_directory, run_dir);
-
-    if (attr_get (attrs, "local-uri", &local_uri, NULL) < 0) {
-        uri = xasprintf ("local://%s", run_dir);
-        if (attr_add (attrs, "local-uri", uri,
-                                            FLUX_ATTRFLAG_IMMUTABLE) < 0)
-            goto done;
-    }
+        cleanup_push_string (cleanup_directory_recursive, run_dir);
     rc = 0;
 done:
     free (dir);
     free (uri);
     return rc;
+}
+
+void create_broker_rundir (overlay_t *ov, void *arg)
+{
+    attr_t *attrs = arg;
+    uint32_t rank;
+    const char *rundir;
+    const char *local_uri;
+    char *broker_rundir = NULL;
+
+    if (attr_get (attrs, "rundir", &rundir, NULL) < 0)
+        log_msg_exit ("create_broker_rundir: rundir attribute not set");
+
+    rank = overlay_get_rank (ov);
+    if (asprintf (&broker_rundir, "%s/%u", rundir, rank) < 0)
+        log_err_exit ("create_broker_rundir: asprintf");
+    if (mkdir (broker_rundir, 0700) < 0)
+        log_err_exit ("create_broker_rundir: mkdir (%s)", broker_rundir);
+    if (attr_add (attrs, "broker.rundir", broker_rundir,
+                         FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        log_err_exit ("create_broker_rundir: attr_add broker.rundir");
+
+    if (attr_get (attrs, "local-uri", &local_uri, NULL) < 0) {
+        char *uri;
+        if (asprintf (&uri, "local://%s", broker_rundir) < 0)
+            log_err_exit ("create_broker_rundir: asprintf (uri)");
+        if (attr_add (attrs, "local-uri", uri, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+            log_err_exit ("create_broker_rundir: attr_add (local-uri)");
+        free (uri);
+    }
+    free (broker_rundir);
 }
 
 /* If 'persist-directory' set, validate it, make it immutable, done.

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -16,9 +16,15 @@
 
 typedef struct overlay_struct overlay_t;
 typedef void (*overlay_cb_f)(overlay_t *ov, void *sock, void *arg);
+typedef void (*overlay_init_cb_f)(overlay_t *ov, void *arg);
 
 overlay_t *overlay_create (void);
 void overlay_destroy (overlay_t *ov);
+
+/* Set a callback triggered during overlay_init()
+ */
+void overlay_set_init_callback (overlay_t *ov,
+                                overlay_init_cb_f cb, void *arg);
 
 /* These need to be called before connect/bind.
  */

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -369,7 +369,7 @@ char *create_scratch_dir (const char *session_id)
 
     if (!mkdtemp (scratchdir))
         log_err_exit ("mkdtemp %s", scratchdir);
-    cleanup_push_string (cleanup_directory, scratchdir);
+    cleanup_push_string (cleanup_directory_recursive, scratchdir);
     return scratchdir;
 }
 
@@ -468,14 +468,9 @@ struct client *client_create (const char *broker_path, const char *scratch_dir,
     cli->rank = rank;
     add_args_list (&argz, &argz_len, ctx.opts, "wrap");
     argz_add (&argz, &argz_len, broker_path);
-    char *run_dir = xasprintf ("%s/%d", scratch_dir, rank);
-    if (mkdir (run_dir, 0755) < 0)
-        log_err_exit ("mkdir %s", run_dir);
-    cleanup_push_string (cleanup_directory, run_dir);
-    char *dir_arg = xasprintf ("--setattr=broker.rundir=%s", run_dir);
+    char *dir_arg = xasprintf ("--setattr=rundir=%s", scratch_dir);
     argz_add (&argz, &argz_len, dir_arg);
     argz_add (&argz, &argz_len, "--setattr=tbon.endpoint=ipc://%B/req");
-    free (run_dir);
     free (dir_arg);
     add_args_list (&argz, &argz_len, ctx.opts, "broker-opts");
     if (rank == 0 && cmd_argz)

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -200,6 +200,11 @@ test_expect_success 'broker.rundir override works' '
 	test -d $RUNDIR &&
 	rmdir $RUNDIR
 '
+test_expect_success 'broker.rundir override creates nonexistent dirs' '
+	RUNDIR="$(pwd)/rundir" &&
+	flux start ${ARGS} -o,--setattr=broker.rundir=$RUNDIR sh -c "test -d $RUNDIR" &&
+	test_expect_code 1 test -d $RUNDIR
+'
 test_expect_success 'broker persist-directory works' '
 	PERSISTDIR=`mktemp -d` &&
 	flux start ${ARGS} -o,--setattr=persist-directory=$PERSISTDIR /bin/true &&

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -173,36 +173,36 @@ test_expect_success 'tbon.parent-endpoint can be read on not rank 0' '
        NUM=`flux start --size 4 flux exec -n flux getattr tbon.parent-endpoint | grep ipc | wc -l` &&
        test $NUM -eq 3
 '
-test_expect_success 'flux start --bootstrap=pmi (singlton) cleans up broker.rundir' '
+test_expect_success 'flux start --bootstrap=pmi (singlton) cleans up rundir' '
 	flux start ${ARGS} --bootstrap=pmi \
-		flux getattr broker.rundir >rundir_pmi.out &&
+		flux getattr rundir >rundir_pmi.out &&
 	RUNDIR=$(cat rundir_pmi.out) &&
 	test_must_fail test -d $RUNDIR
 '
-test_expect_success 'flux start --bootstrap=selfpmi --size=1 cleans up broker.rundirs' '
+test_expect_success 'flux start --bootstrap=selfpmi --size=1 cleans up rundirs' '
 	flux start ${ARGS} --bootstrap=selfpmi --size=1 \
-		flux getattr broker.rundir >rundir_selfpmi1.out &&
+		flux getattr rundir >rundir_selfpmi1.out &&
 	RUNDIR=$(cat rundir_selfpmi1.out) &&
 	test -n "$RUNDIR" &&
-	test_must_fail test -d $(dirname $RUNDIR)
+	test_must_fail test -d $RUNDIR
 '
-test_expect_success 'flux start --bootstrap=selfpmi --size=2 cleans up broker.rundirs' '
+test_expect_success 'flux start --bootstrap=selfpmi --size=2 cleans up rundirs' '
 	flux start ${ARGS} --bootstrap=selfpmi --size=2 \
-		flux getattr broker.rundir >rundir_selfpmi2.out &&
+		flux getattr rundir >rundir_selfpmi2.out &&
 	RUNDIR=$(cat rundir_selfpmi2.out) &&
 	test -n "$RUNDIR" &&
-	test_must_fail test -d $(dirname $RUNDIR)
+	test_must_fail test -d $RUNDIR
 '
-test_expect_success 'broker.rundir override works' '
+test_expect_success 'rundir override works' '
 	RUNDIR=`mktemp -d` &&
-	DIR=`flux start ${ARGS} -o,--setattr=broker.rundir=$RUNDIR flux getattr broker.rundir` &&
+	DIR=`flux start ${ARGS} -o,--setattr=rundir=$RUNDIR flux getattr rundir` &&
 	test "$DIR" = "$RUNDIR" &&
 	test -d $RUNDIR &&
-	rmdir $RUNDIR
+	rm -rf $RUNDIR
 '
-test_expect_success 'broker.rundir override creates nonexistent dirs' '
+test_expect_success 'rundir override creates nonexistent dirs' '
 	RUNDIR="$(pwd)/rundir" &&
-	flux start ${ARGS} -o,--setattr=broker.rundir=$RUNDIR sh -c "test -d $RUNDIR" &&
+	flux start ${ARGS} -o,--setattr=rundir=$RUNDIR sh -c "test -d $RUNDIR" &&
 	test_expect_code 1 test -d $RUNDIR
 '
 test_expect_success 'broker persist-directory works' '
@@ -380,7 +380,7 @@ test_expect_success 'reactor: reactorcat example program works' '
 
 test_expect_success 'flux-start: panic rank 1 of a size=2 instance' '
 	! flux start --killer-timeout=0.2 --bootstrap=selfpmi --size=2 \
-		bash -c "flux getattr broker.rundir; flux comms -r 1 panic fubar; sleep 5" >panic.out 2>panic.err
+		bash -c "flux getattr rundir; flux comms -r 1 panic fubar; sleep 5" >panic.out 2>panic.err
 '
 test_expect_success 'flux-start: panic message reached stderr' '
 	grep -q fubar panic.err
@@ -394,26 +394,6 @@ test_expect_success 'flux-start: rank 0 Killed' '
 	egrep "flux-start: 0 .* Killed" panic.err
 '
 
-# Usage: cleanup_tmpdir tmpdir size
-# Remove tmpdir and expected contents.
-# Could be replaced with rm -rf $tmpdir
-cleanup_tmpdir () {
-	local topdir=$1
-	local size=$2
-	local rank
-
-	for rank in $(seq 0 $(($size-1))); do
-		rm -f $topdir/${rank}/local
-		rm -f $topdir/${rank}/req
-		rmdir $topdir/${rank} || :
-	done
-	rmdir $topdir || :
-}
-
-test_expect_success 'flux-start: cleanup testdir after panic _exit()' '
-	tmpdir=$(dirname $(cat panic.out)) &&
-	test -n "$tmpdir" &&
-	cleanup_tmpdir ${tmpdir} 2
-'
+# Note: flux-start auto-removes rundir
 
 test_done


### PR DESCRIPTION
Backport broker rundir changes from flux-framework/flux-core#2121.

Fixes #3 