### PR TITLE
spectrum.lua: fix for current Spectrum MPI

### DIFF
--- a/src/modules/wreck/lua.d/spectrum.lua
+++ b/src/modules/wreck/lua.d/spectrum.lua
@@ -7,10 +7,19 @@ local posix = require 'posix'
 
 function prepend_path (env_var, path)
     local env = wreck.environ
-    if env[env_var] == nil then
+    local val = env[env_var]
+
+    -- If path is already in env_var, do nothing. We stick ":" on both
+    -- ends of the existing value so we can easily match exact paths
+    -- instead of possibly matching substrings of paths when trying
+    -- to match "zero or more" colons.
+    --
+    if ((":"..val..":"):match (":"..path..":")) then return end
+
+    if val == nil then
        suffix = ''
     else
-       suffix = ':'..env[env_var]
+       suffix = ':'..val
     end
     env[env_var] = path..suffix
 end

--- a/src/modules/wreck/lua.d/spectrum.lua
+++ b/src/modules/wreck/lua.d/spectrum.lua
@@ -15,10 +15,26 @@ function prepend_path (env_var, path)
     env[env_var] = path..suffix
 end
 
+local function strip_env_by_prefix (env, prefix)
+    --
+    -- Have to call env:get() to translate env object to Lua table
+    --  in order to use pairs() to iterate environment keys:
+    --
+    for k,v in pairs (env:get()) do
+        if k:match("^"..prefix) then
+            env[k] = nil
+        end
+    end
+end
+
 function rexecd_init ()
     local env = wreck.environ
     local f = wreck.flux
     local rundir = f:getattr ('broker.rundir')
+
+    -- Clear all existing PMIX_ and OMPI_ values before setting our own
+    strip_env_by_prefix (env, "PMIX_")
+    strip_env_by_prefix (env, "OMPI_")
 
     -- Avoid shared memory segment name collisions
     -- when flux instance runs >1 broker per node.
@@ -28,12 +44,7 @@ function rexecd_init ()
     env['OMPI_MCA_osc'] = "pt2pt"
     env['OMPI_MCA_pml'] = "yalla"
     env['OMPI_MCA_btl'] = "self"
-    env['MPI_ROOT'] = "/opt/ibm/spectrum_mpi"
-    env['OPAL_LIBDIR'] = "/opt/ibm/spectrum_mpi/lib"
     env['OMPI_MCA_coll_hcoll_enable'] = '0'
-
-    env['PMIX_SERVER_URI'] = nil
-    env['PMIX_SERVER_URI2'] = nil
 
     -- Help find libcollectives.so
     prepend_path ('LD_LIBRARY_PATH', '/opt/ibm/spectrum_mpi/lib/pami_port')

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -34,10 +34,13 @@ test_expect_success "intel mpi only rewrites when necessary" '
 '
 
 OPTS="-o mpi=spectrum"
-test_expect_success "spectrum mpi sets MPI_ROOT" '
-  run_program 5 ${SIZE} ${SIZE} printenv MPI_ROOT \
-        | tee spectrum-mpi.env \
-    && test "$(uniq spectrum-mpi.env)" = "/opt/ibm/spectrum_mpi"
+test_expect_success "spectrum mpi unsets all existing PMIX_ OMPI_ vars" '
+    export OMPI_foo=1 &&
+    export PMIX_foo=1 &&
+    run_program 5 ${SIZE} ${SIZE} /usr/bin/env > spectrum-mpi.env && 
+    test_expect_code 1 grep PMIX_foo spectrum-mpi.env &&
+    test_expect_code 1 grep OMPI_foo spectrum-mpi.env &&
+    unset OMPI_foo && unset PMIX_foo
 '
 
 OPTS="-o mpi=spectrum"


### PR DESCRIPTION
As described in #4, update the spectrum.lua plugin to support latest version of Spectrum MPI based on @SteVwonder's debugging effort.

Also had to add support for a `wreck.environ:get()` method to return a copy of the current environment as a Lua table in the wreck/lua plugins. This was the quickest way to allow the current job environment to be iterated.

