### PR TITLE
travis: fix docker deploy from master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ env:
   global:
    - TAP_DRIVER_QUIET=1
    - DOCKERREPO=fluxrm/flux-core
-   - DOCKER_STABLE_PREFIX=-v0.11
+   - DOCKER_STABLE_BRANCH=v0.11
    - DOCKER_USERNAME=travisflux
    # travis encrypt -r flux-framework/flux-core-v0.11
    # DOCKER_PASSWORD=xxxx
@@ -118,10 +118,15 @@ before_install:
  - |
   if test "$DOCKER_TAG" = "t" \
     -a "$TRAVIS_REPO_SLUG" = "flux-framework/flux-core-v0.11" \
-    -a "$TRAVIS_PULL_REQUEST" = "false" \
-    -a \( "$TRAVIS_BRANCH" = "master" -o -n "$TRAVIS_TAG" \); then
-     export TAGNAME="${DOCKERREPO}:${IMG}${TRAVIS_TAG:+-${TRAVIS_TAG}}"
-     echo "Tagging new image $TAGNAME"
+    -a "$TRAVIS_PULL_REQUEST" = "false"; then
+      if test -n "$TRAVIS_TAG"; then
+          # Normal tagged version, use tag as suffix:
+          export TAGNAME="${DOCKERREPO}:${IMG}-${TRAVIS_TAG}"
+      elif test "$TRAVIS_BRANCH" = "master"; then
+          # Builds on master get tagged with "stable branch" suffix:
+          export TAGNAME="${DOCKERREPO}:${IMG}${DOCKER_STABLE_BRANCH:-$DOCKER_STABLE_BRANCH}"
+      fi
+      echo "Tagging new image $TAGNAME"
   fi
 
 script:
@@ -147,10 +152,12 @@ after_success:
   if test -n "$TAGNAME"; then
      echo "$DOCKER_PASSWORD" | \
        docker login -u "$DOCKER_USERNAME" --password-stdin && \
+     echo "docker push ${TAGNAME}"
      docker push ${TAGNAME}
      # If this is the bionic-base build, then also tag without image name:
      if echo "$TAGNAME" | grep -q "bionic"; then
-       t="${DOCKERREPO}:${TRAVIS_TAG:${DOCKER_STABLE_PREFIX}-latest}"
+       t="${DOCKERREPO}:${TRAVIS_TAG:${DOCKER_STABLE_BRANCH}}"
+       echo "docker push ${t}"
        docker tag "$TAGNAME" ${t} && \
        docker push ${t}
      fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/flux-framework/flux-core-v0.11.svg?branch=master)](https://travis-ci.org/flux-framework/flux-core)
-[![Coverage Status](https://coveralls.io/repos/flux-framework/flux-core-v0.11/badge.svg?branch=master&service=github)](https://coveralls.io/github/flux-framework/flux-core?branch=master)
+[![Build Status](https://travis-ci.org/flux-framework/flux-core-v0.11.svg?branch=master)](https://travis-ci.org/flux-framework/flux-core-v0.11)
+[![Coverage Status](https://coveralls.io/repos/flux-framework/flux-core-v0.11/badge.svg?branch=master&service=github)](https://coveralls.io/github/flux-framework/flux-core-v0.11?branch=master)
 
 _NOTE: The interfaces of flux-core are being actively developed
 and are not yet stable._ The github issue tracker is the primary


### PR DESCRIPTION
Docker image deployment from master branch in this repo is currently broken because the docker "tag" ends up being "-v0.11-latest" which is not valid (and the shell chokes on it anyway)

Update the logic controlling the docker tags in .travis.yml with the following
 
 - For clarity, change the name of the variable `DOCKER_STABLE_PREFIX` to `DOCKER_STABLE_BRANCH`, and remove the leading `-`. This variable defines the "stable repo" branch name, in this case `v0.11`.
 - For tags, keep the same logic and push docker tags named `bionic-<tag>` and `centos7-<tag>`. The tagged bionic build is also tagged as just the tag name (e.g. `v0.11.1`).
 - On master, append `-${DOCKER_STABLE_BRANCH}` to the docker tag, e.g. `bionic-v0.11` and `centos7-v0.11`. The bionic build *also* gets tagged as `v0.11` for a shorter name from which to pull the latest v0.11 build. (we could add `-latest` suffix if that is confusing)

Of course, I won't know if this *actually* works until this is merged to master. :cry:
