### PR TITLE
wreck: add support for parallel debuggers with wreckrun

### DIFF
--- a/doc/man1/flux-wreckrun.adoc
+++ b/doc/man1/flux-wreckrun.adoc
@@ -50,6 +50,11 @@ include::wreck-options.adoc[]
 -I::
        Bypass scheduler and run job immediately.
 
+--jobid='id'::
+-J 'id' ::
+	Run a job immediately across the same ranks as a previous job. By
+	default, the number of tasks is set to the number of ranks such
+	that one task per broker rank is executed.
 
 include::wreck-extra-options.adoc[]
 

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -238,6 +238,11 @@ function wreck:getopt (opt)
     return self.opts [opt]
 end
 
+function wreck:setopt (opt, optarg)
+    if not self.opts then error ("setopt called before parse_cmdline") end
+    self.opts [opt] = optarg or true
+end
+
 local function parse_walltime (s)
     local m = { s = 1, m = 60, h = 3600, d = 56400 }
     local n, suffix = s:match ("^([0-9.]+)([HhMmDdSs]?)$")

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -259,8 +259,9 @@ prog:SubCommand {
     local id = check_jobid_arg (self, arg[1])
     local lwj, err = f:kvsdir (kvs_path (id))
     if not lwj then self:die ("Job %d: %s\n", id, err) end
-    if lwj.state ~= "running" then
-        io.stderr:write ("Job "..id..": "..lwj.state.."\n")
+    if lwj.state ~= "running" and lwj.state ~= "sync" then
+        io.stderr:write ("Job "..id..": can't send signal to job in state "..
+                         lwj.state.."\n")
         os.exit (1)
     end
     local sig = opt_sig (self.opt.s)

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -86,6 +86,15 @@ local function fake_R_lite (f, wreck)
     return R_lite
 end
 
+local function jobid_R_lite (f, wreck, id)
+    local p = require 'wreck'.id_to_path { flux = f, jobid = tonumber (id) }
+    local lwj, err = f:kvsdir (p)
+    if not lwj then
+        wreck:die ("Unable to fetch R_lite for jobid %d: %s\n", id, err)
+    end
+    return lwj.R_lite
+end
+
 local function wreckrun_hooks_compile (wreck)
     local code = wreck:getopt ("P")
     local pre_launch_fn = nil
@@ -139,11 +148,16 @@ wreck:add_options ({
         usage = "Do not process stdio, but block until 'STATE'" },
     { name = 'immediate', char = "I",
         usage = "Bypass scheduler and run immediately" },
+    { name = 'jobid', char = "J", arg = "ID",
+        usage = "Run 1 process per rank across ranks of jobid" },
 })
 
 if not wreck:parse_cmdline (arg) then
     wreck:die ("Failed to process cmdline args\n")
 end
+
+-- Set --immediate if --jobid used
+if wreck:getopt ('J') then wreck:setopt ('I') end
 
 -- if nokz is in effect and the --output option is not used, AND
 --  either --detach or --wait-until are active, then store output by
@@ -279,7 +293,19 @@ if not submitted then
     --   -I, --immediate option, manually create R_lite and
     ---  send event to run the job.
     --
-    R_lite = fake_R_lite (f, wreck);
+
+    --  If --jobid used then copy R_lite for targetted job and
+    --   set ntasks equal to the number of ranks (unless overridden
+    --   by --ntasks), otherwise create a fake R_lite:
+    --
+    local id = tonumber (wreck:getopt ("J"))
+    local R_lite = nil
+    if id then
+        R_lite = jobid_R_lite (f, wreck, id)
+        wreck.ntasks  = wreck:getopt ('n') or #R_lite
+    else
+        R_lite = fake_R_lite (f, wreck);
+    end
     if not R_lite then wreck:die ("Failed to generate R_lite\n") end
     lwj.R_lite = R_lite
     lwj:commit()

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -285,6 +285,11 @@ if not wreck:getopt ("I") then
     else
         wreck:verbose ("%-4.03fs: job.submit: %s\n", tt:get0(), err)
     end
+
+    -- If --detach was used, terminate just after scheduler issues runrequest:
+    if wreck:getopt ("d") then
+        wreck:setopt ("w", "runrequest")
+    end
 end
 
 if not submitted then

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -170,6 +170,12 @@ if not jobid then wreck:die ("%s\n", err) end
 
 wreck:verbose ("%4.03fs: Registered jobid %d\n", tt:get0(), jobid)
 
+local jobid_fd = tonumber (os.getenv ("FLUX_WRECKRUN_JOBID_FD"))
+if jobid_fd then
+    posix.write (jobid_fd, jobid.."\n")
+    posix.close (jobid_fd)
+end
+
 --
 --  Get a handle to this lwj kvsdir:
 --

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -79,6 +79,7 @@ TESTS = \
 	t2000-wreck-dummy-sched.t \
 	t2000-wreck-epilog.t \
 	t2000-wreck-nokz.t \
+	t2000-wreck-procdesc.t \
 	t2001-jsc.t \
 	t2002-pmi.t \
 	t2003-recurse.t \
@@ -195,6 +196,7 @@ check_SCRIPTS = \
 	t2000-wreck-dummy-sched.t \
 	t2000-wreck-epilog.t \
 	t2000-wreck-nokz.t \
+	t2000-wreck-procdesc.t \
 	t2001-jsc.t \
 	t2002-pmi.t \
 	t2003-recurse.t \

--- a/t/t2000-wreck-procdesc.t
+++ b/t/t2000-wreck-procdesc.t
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+
+test_description='Test basic wreck procdesc functionality
+
+Test basic functionality of wreck job debugger support
+'
+
+. `dirname $0`/sharness.sh
+SIZE=${FLUX_TEST_SIZE:-4}
+test_under_flux ${SIZE} wreck
+
+KVSWAIT="$SHARNESS_TEST_SRCDIR/scripts/kvs-watch-until.lua"
+
+test_expect_success 'wreckrun procdesc: -o stop-children-in-exec works' '
+	flux wreckrun -n 4 -w sync -o stop-children-in-exec echo hello >output &&
+	flux kvs get $(flux wreck last-jobid -p).0.procdesc &&
+	flux wreck kill -s 9 $(flux wreck last-jobid) &&
+	$KVSWAIT -t 1 $(flux wreck last-jobid -p).state "v == \"complete\""
+'
+test_expect_success 'wreckrun procdesc: procdesc dumped on proctable event' '
+	flux wreckrun -n 4 -w running sleep 300 >output &&
+	flux event pub wreck.$(flux wreck last-jobid).proctable &&
+	flux kvs get --waitcreate $(flux wreck last-jobid -p).0.procdesc &&
+	flux wreck kill -s 9 $(flux wreck last-jobid) &&
+	$KVSWAIT -t 1 $(flux wreck last-jobid -p).state "v == \"complete\""
+'
+test_done

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -210,7 +210,17 @@ test_expect_success 'wreckrun: -t2 -N${SIZE} sets correct ntasks in kvs' '
 	n=$(flux kvs get --json ${LWJ}.ntasks) &&
 	test "$n" = $((${SIZE}*2))
 '
-
+test_expect_success 'wreckrun: -j, --jobid works' '
+	flux wreckrun -d -n 2 -N 2 sleep 300 &&
+	jobid=$(last_job_id) &&
+	flux wreckrun -l --jobid ${jobid} echo hello | sort > jobid.output &&
+	flux wreck kill -s 9 ${jobid} &&
+	cat >jobid.expected <<-EOF &&
+	0: hello
+	1: hello
+	EOF
+	test_cmp jobid.expected jobid.output
+'
 test_expect_success 'wreckrun: ngpus is 0 by default' '
     flux wreckrun -n 2 /bin/true &&
     LWJ=$(last_job_path) &&


### PR DESCRIPTION
Still a work in progress (needs testing), but I thought it might be useful to open a PR since I'll be out the next few days.

This PR is in support of #12. It adds the `--jobid` option to wreckrun as well as simplified support for `FLUX_WRECKRUN_JOBID_FD` as needed by the proposed `flux job-debug`.