### PR TITLE
wreck: add support for a `no-filter-jobid` option

### DIFF
--- a/t/t2000-wreck-env.t
+++ b/t/t2000-wreck-env.t
@@ -70,6 +70,9 @@ test_expect_success 'wreck plugins can use wreck:environ:get()' '
 	UNSETME_foo=1 flux wreckrun /usr/bin/env > all_env.out &&
 	test_expect_code 1 grep UNSETME all_env.out
 '
+test_expect_success 'wreck: SLURM_JOBID is filtered out by default' '
+	test "$(SLURM_JOBID=baz flux wreckrun -n1 printenv SLURM_JOBID)" = ""
+'
 test_expect_success 'wreck: wreckrun -o no-filter-jobid=true works' '
 	test "$(SLURM_JOBID=baz flux wreckrun -o no-filter-jobid=true -n1 printenv SLURM_JOBID)" = "baz"
 '

--- a/t/t2000-wreck-env.t
+++ b/t/t2000-wreck-env.t
@@ -70,5 +70,8 @@ test_expect_success 'wreck plugins can use wreck:environ:get()' '
 	UNSETME_foo=1 flux wreckrun /usr/bin/env > all_env.out &&
 	test_expect_code 1 grep UNSETME all_env.out
 '
+test_expect_success 'wreck: wreckrun -o no-filter-jobid=true works' '
+	test "$(SLURM_JOBID=baz flux wreckrun -o no-filter-jobid=true -n1 printenv SLURM_JOBID)" = "baz"
+'
 
 test_done


### PR DESCRIPTION
Avoid removing "*_JOBID" variables from the job's environment when the
`no-filter-jobid` option is provided to wreck.  Useful when users are
running jobs that leverage libyogrt and need `SLURM_JOBID` and the like
to be passed through.

For more details, see: https://github.com/flux-framework/flux-core/issues/2358